### PR TITLE
Dx 1045 external tables package

### DIFF
--- a/integration_tests/models/plugins/snowflake_external.yml
+++ b/integration_tests/models/plugins/snowflake_external.yml
@@ -52,6 +52,20 @@ sources:
           partitions: *parts-of-the-people
         columns: *cols-of-the-people
         tests: *equal-to-the-people
+
+      - name: people_json_no_refresh_on_create
+        external: 
+          <<: *json-people
+          refresh_on_create: "false"
+        columns: *cols-of-the-people
+        tests: *equal-to-the-people
+
+      - name: people_json_refresh_on_create
+        external: 
+          <<: *json-people
+          refresh_on_create: "true" # Snowflake defaults to this 
+        columns: *cols-of-the-people
+        tests: *equal-to-the-people
         
       - name: people_json_snowpipe
         external:

--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -32,4 +32,4 @@
     {% if external.integration -%} integration = '{{external.integration}}' {%- endif %}
     {% if external.refresh_on_create -%} refresh_on_create = {{external.refresh_on_create}} {%- endif %}
     file_format = {{external.file_format}}
-{% endmacro %}
+{% endmacro %} 

--- a/macros/plugins/snowflake/create_external_table.sql
+++ b/macros/plugins/snowflake/create_external_table.sql
@@ -30,5 +30,6 @@
     {% if external.auto_refresh -%} auto_refresh = {{external.auto_refresh}} {%- endif %}
     {% if external.pattern -%} pattern = '{{external.pattern}}' {%- endif %}
     {% if external.integration -%} integration = '{{external.integration}}' {%- endif %}
+    {% if external.refresh_on_create -%} refresh_on_create = {{external.refresh_on_create}} {%- endif %}
     file_format = {{external.file_format}}
 {% endmacro %}

--- a/sample_sources/snowflake.yml
+++ b/sample_sources/snowflake.yml
@@ -14,7 +14,6 @@ sources:
           location: "@raw.snowplow.snowplow"  # reference an existing external stage
           file_format: "( type = json )"      # fully specified here, or reference an existing file format
           auto_refresh: true                  # requires configuring an event notification from Amazon S3 or Azure
-          refresh_on_create: "false"
           partitions:
             - name: collector_hour
               data_type: timestamp

--- a/sample_sources/snowflake.yml
+++ b/sample_sources/snowflake.yml
@@ -14,6 +14,7 @@ sources:
           location: "@raw.snowplow.snowplow"  # reference an existing external stage
           file_format: "( type = json )"      # fully specified here, or reference an existing file format
           auto_refresh: true                  # requires configuring an event notification from Amazon S3 or Azure
+          refresh_on_create: "false"
           partitions:
             - name: collector_hour
               data_type: timestamp


### PR DESCRIPTION
## Description & motivation
<!---
The macro _snowflake__create_external_table_ has been updated to include the option _refresh_on_create_ for external table creation. If this is not included and the size of the metadata included for files populating the external table exceeds a certain limit, Snowflake raises an error: https://community.snowflake.com/s/article/Create-External-table-failing-with-error-code-001057-0A000

-->

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added an integration test for my fix/feature (if applicable)
